### PR TITLE
Client subnet and several other fixes

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -29,6 +29,12 @@
     - ta.key
   notify: restart openvpn clients
 
+- name: Enable IP forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: 1
+    sysctl_set: yes
+
 - name: Enable openvpn client
   service:
     name: "openvpn@{{ openvpn_server }}"

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -6,10 +6,15 @@
     dest: "{{ openvpn_dir }}/{{ openvpn_server }}.conf"
   notify: restart openvpn clients
 
+- name: Create directory for server-specific files
+  file:
+    path: "{{ openvpn_dir }}/{{ openvpn_server }}"
+    state: directory
+
 - name: Copy client keys to hosts
   copy:
     src: "{{ openvpn_client_certs_dir }}/{{ openvpn_server }}/{{ inventory_hostname }}.{{ item }}"
-    dest: "{{ openvpn_dir }}/"
+    dest: "{{ openvpn_dir }}/{{ openvpn_server }}"
   with_items:
     - crt
     - key
@@ -18,7 +23,7 @@
 - name: Copy TA key and CA certificate
   copy:
     src: "{{ openvpn_client_certs_dir }}/{{ openvpn_server }}/{{ item }}"
-    dest: "{{ openvpn_dir }}/"
+    dest: "{{ openvpn_dir }}/{{ openvpn_server }}/"
   with_items:
     - ca.crt
     - ta.key

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -35,10 +35,11 @@
     value: 1
     sysctl_set: yes
 
-- name: Enable openvpn client
+- name: Enable and start openvpn client
   service:
     name: "openvpn@{{ openvpn_server }}"
     enabled: yes
+    state: started
 
 - meta: flush_handlers
 

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -164,7 +164,7 @@
 - name: Fetch remaining certificates
   fetch:
     src: "{{ item }}"
-    dest: "{{ openvpn_client_certs_dir }}/{{ inventory_hostname }}/" 
+    dest: "{{ openvpn_client_certs_dir }}/{{ inventory_hostname }}/"
     flat: yes
   with_items:
   - "{{ openvpn_easyrsa_dir }}/pki/ca.crt"

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -136,6 +136,15 @@
   with_indexed_items: "{{ openvpn_clients | difference([inventory_hostname]) }}"
   notify: restart openvpn server
 
+- name: Make client subnet reachable by server
+  lineinfile:
+    create: yes
+    path: "{{ openvpn_dir }}/ccd/{{ item }}"
+    regexp: "^iroute"
+    line: "iroute {{ hostvars[item]['ansible_default_ipv4']['network'] }} {{ hostvars[item]['ansible_default_ipv4']['netmask'] }}"
+  with_items: "{{ openvpn_clients | difference([inventory_hostname]) }}"
+  notify: restart openvpn server
+
 - name: Ensure local client certs dir exists
   become: no
   local_action:

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -170,6 +170,12 @@
   - "{{ openvpn_easyrsa_dir }}/pki/ca.crt"
   - "{{ openvpn_dir }}/ta.key"
 
+- name: Enable IP forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: 1
+    sysctl_set: yes
+
 - meta: flush_handlers
 
 ...

--- a/templates/client.conf.j2
+++ b/templates/client.conf.j2
@@ -85,9 +85,9 @@ persist-tun
 # a separate .crt/.key file pair
 # for each client.  A single ca
 # file can be used for all clients.
-ca ca.crt
-cert {{ inventory_hostname }}.crt
-key {{ inventory_hostname }}.key
+ca {{ openvpn_server }}/ca.crt
+cert {{ openvpn_server }}/{{ inventory_hostname }}.crt
+key {{ openvpn_server }}/{{ inventory_hostname }}.key
 
 # Verify server certificate by checking that the
 # certicate has the correct key usage set.
@@ -105,7 +105,7 @@ remote-cert-tls server
 
 # If a tls-auth key is used on the server
 # then every client must also have the key.
-tls-auth ta.key 1
+tls-auth {{ openvpn_server }}/ta.key 1
 
 # Select a cryptographic cipher.
 # If the cipher option is used on the server

--- a/templates/client.conf.j2
+++ b/templates/client.conf.j2
@@ -39,9 +39,7 @@ proto {{ openvpn_server_proto }}
 # The hostname/IP and port of the server.
 # You can have multiple remote entries
 # to load balance between the servers.
-{% for server in openvpn_servers %}
-remote {{ hostvars[server]['ansible_host'] }} {{ openvpn_server_port }}
-{% endfor %}
+remote {{ hostvars[openvpn_server]['ansible_host'] }} {{ openvpn_server_port }}
 ;remote my-server-2 1194
 
 # Choose a random host from the remote

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -159,10 +159,15 @@ push "route {{ ansible_default_ipv4.network }} {{ ansible_default_ipv4.netmask }
 # if you are routing, not bridging, i.e. you are
 # using "dev tun" and "server" directives.
 
+client-config-dir ccd
+{% for item in openvpn_clients %}
+route {{ hostvars[item]['ansible_default_ipv4']['network'] }} {{ hostvars[item]['ansible_default_ipv4']['netmask'] }}
+{% endfor %}
+
 # EXAMPLE: Suppose you want to give
 # Thelonious a fixed VPN IP address of 10.9.0.1.
 # First uncomment out these lines:
-client-config-dir ccd
+;client-config-dir ccd
 ;route 10.9.0.0 255.255.255.252
 # Then add this line to ccd/Thelonious:
 #   ifconfig-push 10.9.0.1 10.9.0.2


### PR DESCRIPTION
Make the default subnet behind OpenVPN clients reachable from the OpenVPN server. This avoids deploying both client and server on each side.

Also includes several small fixes.